### PR TITLE
Add basic login system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple command-line application to log and view daily tasks for supervisors.
 
+The HTML pages now include a basic login system that stores accounts in your
+browser's `localStorage`. Open `login.html` to sign in or create a new account.
+Once logged in you can access `index.html` to select a shift and enter logs.
+
 ## Setup
 
 Create a virtual environment and install dependencies:
@@ -25,3 +29,11 @@ List tasks:
 ```bash
 python -m task_logger.cli list
 ```
+
+### Web interface
+
+1. Open `login.html` in your browser and sign in or create a new account.
+2. After logging in you will be redirected to `index.html` where you can choose
+   the date and shift.
+3. Submit the form to record the shift details. Entries are stored in your
+   browser's `localStorage` along with the supervisor name.

--- a/index.html
+++ b/index.html
@@ -56,8 +56,20 @@
     </style>
 </head>
 <body>
+    <script>
+        const currentUser = localStorage.getItem('currentUser');
+        if (!currentUser) {
+            window.location.href = 'login.html';
+        } else {
+            document.addEventListener('DOMContentLoaded', () => {
+                const welcome = document.getElementById('welcome');
+                if (welcome) welcome.textContent = `Logged in as ${currentUser}`;
+            });
+        }
+    </script>
     <div class="container">
         <h1>Select Shift</h1>
+        <p id="welcome"></p>
         <div class="form-group">
             <label for="date">Date:</label>
             <input type="date" id="date" name="date">

--- a/log.html
+++ b/log.html
@@ -57,6 +57,12 @@
     </style>
 </head>
 <body>
+    <script>
+        const currentUser = localStorage.getItem('currentUser');
+        if (!currentUser) {
+            window.location.href = 'login.html';
+        }
+    </script>
     <div class="container">
         <h1 id="title">Shift Log</h1>
         <div class="form-group">
@@ -95,6 +101,7 @@
 
         document.getElementById('saveBtn').addEventListener('click', function() {
             const entry = {
+                supervisor: currentUser,
                 date: date,
                 shift: shift,
                 safetyTalk: document.getElementById('safetyTalk').value,
@@ -102,7 +109,10 @@
                 checklist: document.getElementById('checklist').value,
                 notes: document.getElementById('notes').value
             };
-            alert('Entry Saved:\n' + JSON.stringify(entry, null, 2));
+            const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+            entries.push(entry);
+            localStorage.setItem('entries', JSON.stringify(entries));
+            alert('Entry Saved');
         });
     </script>
 </body>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f5f5f5;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+        .container {
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+            width: 300px;
+        }
+        .form-group {
+            margin-bottom: 20px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        .error {
+            color: red;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Login</h1>
+        <div class="form-group">
+            <label for="username">Name:</label>
+            <input type="text" id="username">
+        </div>
+        <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password">
+        </div>
+        <button id="loginBtn">Login</button>
+        <p id="error" class="error"></p>
+    </div>
+
+    <script>
+        function loadAccounts() {
+            return JSON.parse(localStorage.getItem('accounts') || '{}');
+        }
+        function saveAccounts(accounts) {
+            localStorage.setItem('accounts', JSON.stringify(accounts));
+        }
+        document.getElementById('loginBtn').addEventListener('click', function() {
+            const user = document.getElementById('username').value.trim();
+            const pass = document.getElementById('password').value;
+            const errorEl = document.getElementById('error');
+            if (!user || !pass) {
+                errorEl.textContent = 'Please enter both name and password.';
+                return;
+            }
+            const accounts = loadAccounts();
+            if (accounts[user] && accounts[user] !== pass) {
+                errorEl.textContent = 'Invalid password';
+                return;
+            }
+            if (!accounts[user]) {
+                accounts[user] = pass; // create new account
+                saveAccounts(accounts);
+            }
+            localStorage.setItem('currentUser', user);
+            window.location.href = 'index.html';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `login.html` to manage simple account storage in localStorage
- restrict `index.html` and `log.html` to logged in users and show login info
- store log entries per supervisor in browser localStorage
- document new web workflow in README

## Testing
- `python -m task_logger.cli list`

------
https://chatgpt.com/codex/tasks/task_e_6846795478ac832db1b63ca40ac3e5c3